### PR TITLE
Implement EventTarget on DynamicProperties

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,24 +4,24 @@ Object.defineProperty(exports, "__esModule", {
 	value: true
 });
 
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+var EMITTER = Symbol('EMITTER');
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
-var DynamicProperties = function (_EventTarget) {
-	_inherits(DynamicProperties, _EventTarget);
-
+var DynamicProperties = function () {
 	function DynamicProperties() {
+		var _this = this;
+
 		var properties = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 		var settings = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : { throttle: 64 };
 
 		_classCallCheck(this, DynamicProperties);
 
-		var _this = _possibleConstructorReturn(this, (DynamicProperties.__proto__ || Object.getPrototypeOf(DynamicProperties)).call(this));
-
 		var cached = {};
+
+		this[EMITTER] = document.createDocumentFragment();
 
 		var addProperty = function addProperty(key, getter) {
 			var element = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
@@ -76,10 +76,32 @@ var DynamicProperties = function (_EventTarget) {
 				_this.dispatchEvent(change);
 			}, settings.throttle);
 		});
-		return _this;
 	}
 
+	_createClass(DynamicProperties, [{
+		key: 'addEventListener',
+		value: function addEventListener() {
+			var _EMITTER;
+
+			(_EMITTER = this[EMITTER]).addEventListener.apply(_EMITTER, arguments);
+		}
+	}, {
+		key: 'removeEventListener',
+		value: function removeEventListener() {
+			var _EMITTER2;
+
+			(_EMITTER2 = this[EMITTER]).removeEventListener.apply(_EMITTER2, arguments);
+		}
+	}, {
+		key: 'dispatchEvent',
+		value: function dispatchEvent() {
+			var _EMITTER3;
+
+			(_EMITTER3 = this[EMITTER]).dispatchEvent.apply(_EMITTER3, arguments);
+		}
+	}]);
+
 	return DynamicProperties;
-}(EventTarget);
+}();
 
 exports.default = DynamicProperties;

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,100 +8,92 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-var EMITTER = Symbol('EMITTER');
+exports.default = function () {
+	var EMITTER = document.createDocumentFragment();
 
-var DynamicProperties = function () {
-	function DynamicProperties() {
-		var _this = this;
+	return function () {
+		function DynamicProperties() {
+			var _this = this;
 
-		var properties = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-		var settings = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : { throttle: 64 };
+			var properties = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+			var settings = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : { throttle: 64 };
 
-		_classCallCheck(this, DynamicProperties);
+			_classCallCheck(this, DynamicProperties);
 
-		var cached = {};
+			var cached = {};
 
-		this[EMITTER] = document.createDocumentFragment();
+			var addProperty = function addProperty(key, getter) {
+				var element = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
 
-		var addProperty = function addProperty(key, getter) {
-			var element = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
-
-			if (typeof _this[key] !== 'undefined') {
-				console.warn(key, 'is already defined in this property list');
-				return false;
-			}
-
-			Object.defineProperty(_this, key, {
-				enumerable: true,
-				configurable: true,
-				get: function get() {
-					if (typeof cached[key] === 'undefined') {
-						if (element) {
-							cached[key] = getter.call(element);
-						} else {
-							cached[key] = getter();
-						}
-					}
-
-					return cached[key];
+				if (typeof _this[key] !== 'undefined') {
+					console.warn(key, 'is already defined in this property list');
+					return false;
 				}
+
+				Object.defineProperty(_this, key, {
+					enumerable: true,
+					configurable: true,
+					get: function get() {
+						if (typeof cached[key] === 'undefined') {
+							if (element) {
+								cached[key] = getter.call(element);
+							} else {
+								cached[key] = getter();
+							}
+						}
+
+						return cached[key];
+					}
+				});
+
+				return _this;
+			};
+
+			for (var key in properties) {
+				var getter = properties[key];
+
+				if (typeof getter === 'function') {
+					addProperty(key, getter);
+				} else if (typeof getter !== 'string' && getter.length) {
+					// Lazy array check
+					addProperty(key, getter[0], getter[1] || window);
+				}
+			}
+
+			// Reset cache on resize
+			var resizeTimeout = void 0;
+			window.addEventListener('resize', function (e) {
+				if (resizeTimeout) {
+					clearTimeout(resizeTimeout);
+				}
+
+				resizeTimeout = setTimeout(function () {
+					cached = {};
+					resizeTimeout = undefined;
+
+					var change = new Event('change');
+					_this.dispatchEvent(change);
+				}, settings.throttle);
 			});
+		}
 
-			return _this;
-		};
-
-		for (var key in properties) {
-			var getter = properties[key];
-
-			if (typeof getter === 'function') {
-				addProperty(key, getter);
-			} else if (typeof getter !== 'string' && getter.length) {
-				// Lazy array check
-				addProperty(key, getter[0], getter[1] || window);
+		_createClass(DynamicProperties, [{
+			key: 'addEventListener',
+			value: function addEventListener() {
+				EMITTER.addEventListener.apply(EMITTER, arguments);
 			}
-		}
-
-		// Reset cache on resize
-		var resizeTimeout = void 0;
-		window.addEventListener('resize', function (e) {
-			if (resizeTimeout) {
-				clearTimeout(resizeTimeout);
+		}, {
+			key: 'removeEventListener',
+			value: function removeEventListener() {
+				EMITTER.removeEventListener.apply(EMITTER, arguments);
 			}
+		}, {
+			key: 'dispatchEvent',
+			value: function dispatchEvent() {
+				EMITTER.dispatchEvent.apply(EMITTER, arguments);
+			}
+		}]);
 
-			resizeTimeout = setTimeout(function () {
-				cached = {};
-				resizeTimeout = undefined;
-
-				var change = new Event('change');
-				_this.dispatchEvent(change);
-			}, settings.throttle);
-		});
-	}
-
-	_createClass(DynamicProperties, [{
-		key: 'addEventListener',
-		value: function addEventListener() {
-			var _EMITTER;
-
-			(_EMITTER = this[EMITTER]).addEventListener.apply(_EMITTER, arguments);
-		}
-	}, {
-		key: 'removeEventListener',
-		value: function removeEventListener() {
-			var _EMITTER2;
-
-			(_EMITTER2 = this[EMITTER]).removeEventListener.apply(_EMITTER2, arguments);
-		}
-	}, {
-		key: 'dispatchEvent',
-		value: function dispatchEvent() {
-			var _EMITTER3;
-
-			(_EMITTER3 = this[EMITTER]).dispatchEvent.apply(_EMITTER3, arguments);
-		}
-	}]);
-
-	return DynamicProperties;
+		return DynamicProperties;
+	}();
 }();
-
-exports.default = DynamicProperties;

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,66 +6,80 @@ Object.defineProperty(exports, "__esModule", {
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-var DynamicProperties = function DynamicProperties() {
-	var _this = this;
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
-	var properties = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-	var settings = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : { throttle: 64 };
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-	_classCallCheck(this, DynamicProperties);
+var DynamicProperties = function (_EventTarget) {
+	_inherits(DynamicProperties, _EventTarget);
 
-	var cached = {};
+	function DynamicProperties() {
+		var properties = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+		var settings = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : { throttle: 64 };
 
-	var addProperty = function addProperty(key, getter) {
-		var element = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
+		_classCallCheck(this, DynamicProperties);
 
-		if (typeof _this[key] !== 'undefined') {
-			console.warn(key, 'is already defined in this property list');
-			return false;
-		}
+		var _this = _possibleConstructorReturn(this, (DynamicProperties.__proto__ || Object.getPrototypeOf(DynamicProperties)).call(this));
 
-		Object.defineProperty(_this, key, {
-			enumerable: true,
-			configurable: true,
-			get: function get() {
-				if (typeof cached[key] === 'undefined') {
-					if (element) {
-						cached[key] = getter.call(element);
-					} else {
-						cached[key] = getter();
-					}
-				}
+		var cached = {};
 
-				return cached[key];
+		var addProperty = function addProperty(key, getter) {
+			var element = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
+
+			if (typeof _this[key] !== 'undefined') {
+				console.warn(key, 'is already defined in this property list');
+				return false;
 			}
-		});
 
-		return _this;
-	};
+			Object.defineProperty(_this, key, {
+				enumerable: true,
+				configurable: true,
+				get: function get() {
+					if (typeof cached[key] === 'undefined') {
+						if (element) {
+							cached[key] = getter.call(element);
+						} else {
+							cached[key] = getter();
+						}
+					}
 
-	for (var key in properties) {
-		var getter = properties[key];
+					return cached[key];
+				}
+			});
 
-		if (typeof getter === 'function') {
-			addProperty(key, getter);
-		} else if (typeof getter !== 'string' && getter.length) {
-			// Lazy array check
-			addProperty(key, getter[0], getter[1] || window);
+			return _this;
+		};
+
+		for (var key in properties) {
+			var getter = properties[key];
+
+			if (typeof getter === 'function') {
+				addProperty(key, getter);
+			} else if (typeof getter !== 'string' && getter.length) {
+				// Lazy array check
+				addProperty(key, getter[0], getter[1] || window);
+			}
 		}
+
+		// Reset cache on resize
+		var resizeTimeout = void 0;
+		window.addEventListener('resize', function (e) {
+			if (resizeTimeout) {
+				clearTimeout(resizeTimeout);
+			}
+
+			resizeTimeout = setTimeout(function () {
+				cached = {};
+				resizeTimeout = undefined;
+
+				var change = new Event('change');
+				_this.dispatchEvent(change);
+			}, settings.throttle);
+		});
+		return _this;
 	}
 
-	// Reset cache on resize
-	var resizeTimeout = void 0;
-	window.addEventListener('resize', function (e) {
-		if (resizeTimeout) {
-			clearTimeout(resizeTimeout);
-		}
-
-		resizeTimeout = setTimeout(function () {
-			cached = {};
-			resizeTimeout = undefined;
-		}, settings.throttle);
-	});
-};
+	return DynamicProperties;
+}(EventTarget);
 
 exports.default = DynamicProperties;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
-export default class DynamicProperties {
+export default class DynamicProperties extends EventTarget {
 
 	constructor(properties = {}, settings = { throttle: 64 }) {
+		super();
+
 		let cached = {};
 
 		const addProperty = (key, getter, element = null) => {
@@ -49,6 +51,9 @@ export default class DynamicProperties {
 			resizeTimeout = setTimeout(() => {
 				cached = {};
 				resizeTimeout = undefined;
+
+				const change = new Event('change');
+				this.dispatchEvent(change);
 			}, settings.throttle);
 		});
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
-export default class DynamicProperties extends EventTarget {
+const EMITTER = Symbol('EMITTER');
+
+export default class DynamicProperties {
 
 	constructor(properties = {}, settings = { throttle: 64 }) {
-		super();
-
 		let cached = {};
+
+		this[EMITTER] = document.createDocumentFragment();
 
 		const addProperty = (key, getter, element = null) => {
 			if (typeof this[key] !== 'undefined') {
@@ -56,6 +58,18 @@ export default class DynamicProperties extends EventTarget {
 				this.dispatchEvent(change);
 			}, settings.throttle);
 		});
+	}
+
+	addEventListener(...args) {
+		this[EMITTER].addEventListener(...args);
+	}
+
+	removeEventListener(...args) {
+		this[EMITTER].removeEventListener(...args);
+	}
+
+	dispatchEvent(...args) {
+		this[EMITTER].dispatchEvent(...args);
 	}
 
 }


### PR DESCRIPTION
There is currently no way to know when the values of the dynamic properties object have updated.
This makes this library kind of useless if you want to do something whenever the values change (e.g. re-render). When doing so, you still had to either run a rAF or listen for window resizes anyway.

~In this PR, I extend from the [`EventTarget`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget) implementation so~ we can use `addEventListener`.

```es6
const dimensions = new DynamicProperties({
	windowWidth: () => Math.floor(window.innerWidth),
	windowHeight: () => Math.floor(window.innerHeight),
}, { throttle: 128 });

const render = () => {
	const { windowWidth, windowHeight } = dimensions;
	document.body.textContent = `${windowWidth}px by ${windowHeight}px`;
};

render();

dimensions.addEventListener('change', () => {
	render();
});
```